### PR TITLE
Fix language statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+athena/* linguist-vendored


### PR DESCRIPTION
Fix the language statistics feature by ignoring the `athena` directory, which is a third-party directory consisting of code from the WPILib HAL, when calculating language breakdowns.