### PR TITLE
Feature joystick

### DIFF
--- a/examples/test_robot.rs
+++ b/examples/test_robot.rs
@@ -7,7 +7,7 @@ struct TestRobot;
 impl Robot for TestRobot {
     fn run(self) {
         println!("Running!");
-        let stick = Joystick::new(0);
+        let mut stick = Joystick::new(0);
         loop {
             println!("{:?}", stick.get_raw_axis(1));
             println!("{:?}", fpga::get_time_us());

--- a/examples/test_robot.rs
+++ b/examples/test_robot.rs
@@ -7,8 +7,9 @@ struct TestRobot;
 impl Robot for TestRobot {
     fn run(self) {
         println!("Running!");
+        let stick = Joystick::new(0);
         loop {
-            println!("{:?}", DriverStation::instance().get_joystick_axis(0, 1));
+            println!("{:?}", stick.get_raw_axis(1));
             println!("{:?}", fpga::get_time_us());
         }
     }

--- a/src/wpilib/driverstation.rs
+++ b/src/wpilib/driverstation.rs
@@ -181,7 +181,7 @@ impl DriverStation {
     }
 
     /// Report a message at a throttled rate
-    fn report_throttled(&mut self, is_error: bool, message: &str) {
+    pub fn report_throttled(&mut self, is_error: bool, message: &str) {
         // Don't actually throttle it; FPGA timer is unimplemented
         let now = 1f64;
         if self.report_throttler.update(now) {

--- a/src/wpilib/joystick.rs
+++ b/src/wpilib/joystick.rs
@@ -7,8 +7,8 @@ const RUMBLE_BASE: i32 = 65535;
 
 #[derive(PartialEq)]
 pub enum JoystickSide {
-    kLeftHand,
-    kRightHand,
+    LeftHand,
+    RightHand,
 }
 
 #[derive(PartialEq)]
@@ -51,21 +51,21 @@ impl JoystickBase for Joystick {
     fn get_raw_axis(&mut self, axis: usize) -> f32 {
         match self.ds.get_joystick_axis(self.port, axis) {
             Ok(val) => val,
-            Err(e) => 0f32,
+            _ => 0f32,
         }
     }
 
     fn get_raw_button(&mut self, button: usize) -> bool {
         match self.ds.get_joystick_button(self.port, button) {
             Ok(val) => val,
-            Err(e) => false,
+            _ => false,
         }
     }
 
     fn get_pov(&mut self, pov: usize) -> i16 {
         match self.ds.get_joystick_pov(self.port, pov) {
             Ok(val) => val,
-            Err(e) => -01,
+            _ => -01,
         }
     }
 
@@ -81,17 +81,12 @@ impl JoystickBase for Joystick {
     }
 
     fn set_rumble(&mut self, side: JoystickSide, mut value: f32) {
-        if value < 0f32 {
-            value = 0f32;
-        } else if value > 1f32 {
-            value = 1f32;
+        value = if value > 1f32 { 1f32 } else if value < 0f32 { 0f32 } else { value };
+        match side {
+            JoystickSide::LeftHand => self.left_rumble = (value * RUMBLE_BASE as f32) as i32,
+            JoystickSide::RightHand => self.right_rumble = (value * RUMBLE_BASE as f32) as i32,
         }
-        if side == JoystickSide::kLeftHand {
-            self.left_rumble = (value * RUMBLE_BASE as f32) as i32;
-        } else {
-            self.right_rumble = (value * RUMBLE_BASE as f32) as i32;
-        }
-        unsafe { HAL_SetJoystickOutputs(self.port as i32, self.outputs, self.left_rumble, self.right_rumble); }
+        unsafe { HAL_SetJoystickOutputs(self.port as i32, self.outputs, self.left_rumble, self.right_rumble) };
     }
 }
 
@@ -126,10 +121,9 @@ impl XBoxController {
     }
 
     pub fn get_bumper(&mut self, side: JoystickSide) -> bool {
-        if side == JoystickSide::kLeftHand {
-            self.get_raw_button(5)
-        } else {
-            self.get_raw_button(6)
+        match side {
+            JoystickSide::LeftHand => self.get_raw_button(5),
+            JoystickSide::RightHand => self.get_raw_button(6),
         }
     }
 
@@ -142,35 +136,31 @@ impl XBoxController {
     }
 
     pub fn get_axis_button(&mut self, side: JoystickSide) -> bool {
-        if side == JoystickSide::kLeftHand {
-            self.get_raw_button(9)
-        } else {
-            self.get_raw_button(10)
+        match side {
+            JoystickSide::LeftHand => self.get_raw_button(9),
+            JoystickSide::RightHand => self.get_raw_button(10),
         }
     }
 
     //axes
     pub fn get_x(&mut self, side: JoystickSide) -> f32 {
-        if side == JoystickSide::kLeftHand {
-            self.get_raw_axis(0)
-        } else {
-            self.get_raw_axis(4)
+        match side {
+            JoystickSide::LeftHand => self.get_raw_axis(0),
+            JoystickSide::RightHand => self.get_raw_axis(4),
         }
     }
 
     pub fn get_y(&mut self, side: JoystickSide) -> f32 {
-        if side == JoystickSide::kLeftHand {
-            self.get_raw_axis(1)
-        } else {
-            self.get_raw_axis(5)
+        match side {
+            JoystickSide::LeftHand => self.get_raw_axis(1),
+            JoystickSide::RightHand => self.get_raw_axis(5),
         }
     }
 
     pub fn get_trigger(&mut self, side: JoystickSide) -> f32 {
-        if side == JoystickSide::kLeftHand {
-            self.get_raw_axis(2)
-        } else {
-            self.get_raw_axis(3)
+        match side {
+            JoystickSide::LeftHand => self.get_raw_axis(2),
+            JoystickSide::RightHand => self.get_raw_axis(3),
         }
     }
 
@@ -193,21 +183,21 @@ impl JoystickBase for XBoxController {
     fn get_raw_axis(&mut self, axis: usize) -> f32 {
         match self.ds.get_joystick_axis(self.port, axis) {
             Ok(val) => val,
-            Err(e) => 0f32,
+            _ => 0f32,
         }
     }
 
     fn get_raw_button(&mut self, button: usize) -> bool {
         match self.ds.get_joystick_button(self.port, button) {
             Ok(val) => val,
-            Err(e) => false,
+            _ => false,
         }
     }
 
     fn get_pov(&mut self, pov: usize) -> i16 {
         match self.ds.get_joystick_pov(self.port, pov) {
             Ok(val) => val,
-            Err(e) => -01,
+            _ => -01,
         }
     }
 
@@ -223,15 +213,10 @@ impl JoystickBase for XBoxController {
     }
 
     fn set_rumble(&mut self, side: JoystickSide, mut value: f32) {
-        if value < 0f32 {
-            value = 0f32;
-        } else if value > 1f32 {
-            value = 1f32;
-        }
-        if side == JoystickSide::kLeftHand {
-            self.left_rumble = (value * RUMBLE_BASE as f32) as i32;
-        } else {
-            self.right_rumble = (value * RUMBLE_BASE as f32) as i32;
+        value = if value > 1f32 { 1f32 } else if value < 0f32 { 0f32 } else { value };
+        match side {
+            JoystickSide::LeftHand => self.left_rumble = (value * RUMBLE_BASE as f32) as i32,
+            JoystickSide::RightHand => self.right_rumble = (value * RUMBLE_BASE as f32) as i32,
         }
         unsafe { HAL_SetJoystickOutputs(self.port as i32, self.outputs, self.left_rumble, self.right_rumble) };
     }

--- a/src/wpilib/joystick.rs
+++ b/src/wpilib/joystick.rs
@@ -1,10 +1,7 @@
 #![allow(missing_docs)]
 
 use wpilib::wpilib_hal::*;
-use wpilib::hal_call::*;
 use wpilib::driverstation::*;
-
-use std::ops::*;
 
 const RUMBLE_BASE: i32 = 65535;
 
@@ -45,7 +42,7 @@ pub struct Joystick {
 }
 
 impl Joystick {
-    fn new(p: usize) -> Joystick {
+    pub fn new(p: usize) -> Joystick {
         Joystick { port: p, ds: DriverStation::instance(), outputs: 0i64, left_rumble: 0i32, right_rumble: 0i32 }
     }
 }
@@ -107,28 +104,28 @@ pub struct XBoxController {
 }
 
 impl XBoxController {
-    fn new(p: usize) -> XBoxController {
+    pub fn new(p: usize) -> XBoxController {
         XBoxController { port: p, ds: DriverStation::instance(), outputs: 0i64, left_rumble: 0i32, right_rumble: 0i32 }
     }
 
     //buttons
-    fn get_a_button(&mut self) -> bool {
+    pub fn get_a_button(&mut self) -> bool {
         self.get_raw_button(1)
     }
 
-    fn get_b_button(&mut self) -> bool {
+    pub fn get_b_button(&mut self) -> bool {
         self.get_raw_button(2)
     }
 
-    fn get_x_button(&mut self) -> bool {
+    pub fn get_x_button(&mut self) -> bool {
         self.get_raw_button(3)
     }
 
-    fn get_y_button(&mut self) -> bool {
+    pub fn get_y_button(&mut self) -> bool {
         self.get_raw_button(4)
     }
 
-    fn get_bumper(&mut self, side: JoystickSide) -> bool {
+    pub fn get_bumper(&mut self, side: JoystickSide) -> bool {
         if side == JoystickSide::kLeftHand {
             self.get_raw_button(5)
         } else {
@@ -136,15 +133,15 @@ impl XBoxController {
         }
     }
 
-    fn get_back_button(&mut self) -> bool {
+    pub fn get_back_button(&mut self) -> bool {
         self.get_raw_button(7)
     }
 
-    fn get_start_button(&mut self) -> bool {
+    pub fn get_start_button(&mut self) -> bool {
         self.get_raw_button(8)
     }
 
-    fn get_axis_button(&mut self, side: JoystickSide) -> bool {
+    pub fn get_axis_button(&mut self, side: JoystickSide) -> bool {
         if side == JoystickSide::kLeftHand {
             self.get_raw_button(9)
         } else {
@@ -153,7 +150,7 @@ impl XBoxController {
     }
 
     //axes
-    fn get_x(&mut self, side: JoystickSide) -> f32 {
+    pub fn get_x(&mut self, side: JoystickSide) -> f32 {
         if side == JoystickSide::kLeftHand {
             self.get_raw_axis(0)
         } else {
@@ -161,7 +158,7 @@ impl XBoxController {
         }
     }
 
-    fn get_y(&mut self, side: JoystickSide) -> f32 {
+    pub fn get_y(&mut self, side: JoystickSide) -> f32 {
         if side == JoystickSide::kLeftHand {
             self.get_raw_axis(1)
         } else {
@@ -169,7 +166,7 @@ impl XBoxController {
         }
     }
 
-    fn get_trigger(&mut self, side: JoystickSide) -> f32 {
+    pub fn get_trigger(&mut self, side: JoystickSide) -> f32 {
         if side == JoystickSide::kLeftHand {
             self.get_raw_axis(2)
         } else {
@@ -177,7 +174,7 @@ impl XBoxController {
         }
     }
 
-    fn get_dpad(&mut self) -> DPAD {
+    pub fn get_dpad(&mut self) -> DPAD {
         match self.get_pov(1) {
             0 => DPAD::Up,
             1 => DPAD::UpRight,

--- a/src/wpilib/joystick.rs
+++ b/src/wpilib/joystick.rs
@@ -1,0 +1,241 @@
+#![allow(missing_docs)]
+
+use wpilib::wpilib_hal::*;
+use wpilib::hal_call::*;
+use wpilib::driverstation::*;
+
+use std::ops::*;
+
+const RUMBLE_BASE: i32 = 65535;
+
+#[derive(PartialEq)]
+pub enum JoystickSide {
+    kLeftHand,
+    kRightHand,
+}
+
+#[derive(PartialEq)]
+pub enum DPAD {
+    Neutral,
+    Up,
+    Down,
+    Left,
+    Right,
+    UpRight,
+    DownRight,
+    UpLeft,
+    DownLeft,
+}
+
+pub trait JoystickBase {
+    fn get_raw_axis(&mut self, axis: usize) -> f32;
+    fn get_raw_button(&mut self, button: usize) -> bool;
+    fn get_pov(&mut self, pov: usize) -> i16;
+    fn set_output(&mut self, output_number: i32, value: bool);
+    fn set_outputs(&mut self, value: i64);
+    fn set_rumble(&mut self, side: JoystickSide, value: f32);
+}
+
+pub struct Joystick {
+    port: usize,
+    ds: &'static mut DriverStation,
+    outputs: i64,
+    left_rumble: i32,
+    right_rumble: i32,
+}
+
+impl Joystick {
+    fn new(p: usize) -> Joystick {
+        Joystick { port: p, ds: DriverStation::instance(), outputs: 0i64, left_rumble: 0i32, right_rumble: 0i32 }
+    }
+}
+
+impl JoystickBase for Joystick {
+    fn get_raw_axis(&mut self, axis: usize) -> f32 {
+        match self.ds.get_joystick_axis(self.port, axis) {
+            Ok(val) => val,
+            Err(e) => 0f32,
+        }
+    }
+
+    fn get_raw_button(&mut self, button: usize) -> bool {
+        match self.ds.get_joystick_button(self.port, button) {
+            Ok(val) => val,
+            Err(e) => false,
+        }
+    }
+
+    fn get_pov(&mut self, pov: usize) -> i16 {
+        match self.ds.get_joystick_pov(self.port, pov) {
+            Ok(val) => val,
+            Err(e) => -01,
+        }
+    }
+
+    fn set_output(&mut self, output_number: i32, value: bool) {
+        let o = output_number - 1i32;
+        self.outputs = (self.outputs & (!(1i32 << o)) as i64) | ((value as i64) << o);
+        unsafe { HAL_SetJoystickOutputs(self.port as i32, self.outputs, self.left_rumble, self.right_rumble); }
+    }
+
+    fn set_outputs(&mut self, value: i64) {
+        self.outputs = value;
+        unsafe { HAL_SetJoystickOutputs(self.port as i32, self.outputs, self.left_rumble, self.right_rumble); }
+    }
+
+    fn set_rumble(&mut self, side: JoystickSide, mut value: f32) {
+        if value < 0f32 {
+            value = 0f32;
+        } else if value > 1f32 {
+            value = 1f32;
+        }
+        if side == JoystickSide::kLeftHand {
+            self.left_rumble = (value * RUMBLE_BASE as f32) as i32;
+        } else {
+            self.right_rumble = (value * RUMBLE_BASE as f32) as i32;
+        }
+        unsafe { HAL_SetJoystickOutputs(self.port as i32, self.outputs, self.left_rumble, self.right_rumble); }
+    }
+}
+
+pub struct XBoxController {
+    port: usize,
+    ds: &'static mut DriverStation,
+    outputs: i64,
+    left_rumble: i32,
+    right_rumble: i32,
+}
+
+impl XBoxController {
+    fn new(p: usize) -> XBoxController {
+        XBoxController { port: p, ds: DriverStation::instance(), outputs: 0i64, left_rumble: 0i32, right_rumble: 0i32 }
+    }
+
+    //buttons
+    fn get_a_button(&mut self) -> bool {
+        self.get_raw_button(1)
+    }
+
+    fn get_b_button(&mut self) -> bool {
+        self.get_raw_button(2)
+    }
+
+    fn get_x_button(&mut self) -> bool {
+        self.get_raw_button(3)
+    }
+
+    fn get_y_button(&mut self) -> bool {
+        self.get_raw_button(4)
+    }
+
+    fn get_bumper(&mut self, side: JoystickSide) -> bool {
+        if side == JoystickSide::kLeftHand {
+            self.get_raw_button(5)
+        } else {
+            self.get_raw_button(6)
+        }
+    }
+
+    fn get_back_button(&mut self) -> bool {
+        self.get_raw_button(7)
+    }
+
+    fn get_start_button(&mut self) -> bool {
+        self.get_raw_button(8)
+    }
+
+    fn get_axis_button(&mut self, side: JoystickSide) -> bool {
+        if side == JoystickSide::kLeftHand {
+            self.get_raw_button(9)
+        } else {
+            self.get_raw_button(10)
+        }
+    }
+
+    //axes
+    fn get_x(&mut self, side: JoystickSide) -> f32 {
+        if side == JoystickSide::kLeftHand {
+            self.get_raw_axis(0)
+        } else {
+            self.get_raw_axis(4)
+        }
+    }
+
+    fn get_y(&mut self, side: JoystickSide) -> f32 {
+        if side == JoystickSide::kLeftHand {
+            self.get_raw_axis(1)
+        } else {
+            self.get_raw_axis(5)
+        }
+    }
+
+    fn get_trigger(&mut self, side: JoystickSide) -> f32 {
+        if side == JoystickSide::kLeftHand {
+            self.get_raw_axis(2)
+        } else {
+            self.get_raw_axis(3)
+        }
+    }
+
+    fn get_dpad(&mut self) -> DPAD {
+        match self.get_pov(1) {
+            0 => DPAD::Up,
+            1 => DPAD::UpRight,
+            2 => DPAD::Right,
+            3 => DPAD::DownRight,
+            4 => DPAD::Down,
+            5 => DPAD::DownLeft,
+            6 => DPAD::Left,
+            7 => DPAD::UpLeft,
+            _ => DPAD::Neutral,
+        }
+    }
+ }
+
+impl JoystickBase for XBoxController {
+    fn get_raw_axis(&mut self, axis: usize) -> f32 {
+        match self.ds.get_joystick_axis(self.port, axis) {
+            Ok(val) => val,
+            Err(e) => 0f32,
+        }
+    }
+
+    fn get_raw_button(&mut self, button: usize) -> bool {
+        match self.ds.get_joystick_button(self.port, button) {
+            Ok(val) => val,
+            Err(e) => false,
+        }
+    }
+
+    fn get_pov(&mut self, pov: usize) -> i16 {
+        match self.ds.get_joystick_pov(self.port, pov) {
+            Ok(val) => val,
+            Err(e) => -01,
+        }
+    }
+
+    fn set_output(&mut self, output_number: i32, value: bool) {
+        let o = output_number - 1i32;
+        self.outputs = (self.outputs & (!(1i32 << o)) as i64) | ((value as i64) << o);
+        unsafe { HAL_SetJoystickOutputs(self.port as i32, self.outputs, self.left_rumble, self.right_rumble); }
+    }
+
+    fn set_outputs(&mut self, value: i64) {
+        self.outputs = value;
+        unsafe { HAL_SetJoystickOutputs(self.port as i32, self.outputs, self.left_rumble, self.right_rumble); }
+    }
+
+    fn set_rumble(&mut self, side: JoystickSide, mut value: f32) {
+        if value < 0f32 {
+            value = 0f32;
+        } else if value > 1f32 {
+            value = 1f32;
+        }
+        if side == JoystickSide::kLeftHand {
+            self.left_rumble = (value * RUMBLE_BASE as f32) as i32;
+        } else {
+            self.right_rumble = (value * RUMBLE_BASE as f32) as i32;
+        }
+        unsafe { HAL_SetJoystickOutputs(self.port as i32, self.outputs, self.left_rumble, self.right_rumble) };
+    }
+}

--- a/src/wpilib/mod.rs
+++ b/src/wpilib/mod.rs
@@ -57,5 +57,6 @@ pub use self::speed_controller::*;
 mod pwm_speed_controller;
 pub use self::pwm_speed_controller::*;
 
+/// defines all joystick related traits and structs
 pub mod joystick;
 pub use self::joystick::*;

--- a/src/wpilib/mod.rs
+++ b/src/wpilib/mod.rs
@@ -56,3 +56,6 @@ pub use self::speed_controller::*;
 
 mod pwm_speed_controller;
 pub use self::pwm_speed_controller::*;
+
+pub mod joystick;
+pub use self::joystick::*;


### PR DESCRIPTION
Basic joystick struct and xbox controller helper struct. The only thing unimplemented from wpilib is the ability to get x, y, or z from the generic joystick class.