### PR TITLE
Use absolute paths for linking in build script

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,5 @@
+use std::env;
+
 fn main() {
     for lib in ["HALAthena",
                 "wpiutil",
@@ -15,6 +17,8 @@ fn main() {
         println!("cargo:rustc-link-lib=dylib={}", lib);
     }
 
-    println!("cargo:rustc-link-search=native=ni-libraries");
-    println!("cargo:rustc-link-search=native=athena/lib");
+    let path = env::current_dir().unwrap();
+
+    println!("cargo:rustc-link-search=native={}/ni-libraries", path.display());
+    println!("cargo:rustc-link-search=native={}/athena/lib", path.display());
 }


### PR DESCRIPTION
This fixes the build system to allow for `rust-wpilib` to be used as a dependency of other crates.