### PR TITLE
PCM and solenoids

### DIFF
--- a/examples/test_robot.rs
+++ b/examples/test_robot.rs
@@ -1,4 +1,3 @@
-#[macro_use]
 extern crate wpilib;
 use wpilib::*;
 
@@ -8,9 +7,13 @@ impl Robot for TestRobot {
     fn run(self) {
         println!("Running!");
         let mut stick = Joystick::new(0);
+        let pcm = BufferedPcm::new(0).unwrap();
+        let mut solenoid = pcm.make_solenoid(0).unwrap();
         loop {
             println!("{:?}", stick.get_raw_axis(1));
             println!("{:?}", fpga::get_time_us());
+            solenoid.set(true);
+            pcm.flush().unwrap();
         }
     }
 

--- a/src/wpilib/can.rs
+++ b/src/wpilib/can.rs
@@ -19,7 +19,7 @@ pub enum CanError {
     /// Caller attempted to insert data into a buffer that is full.
     BufferFull,
     /// Some other error happened
-    Other(HalError)
+    Other(HalError),
 }
 
 impl From<i32> for CanError {

--- a/src/wpilib/can.rs
+++ b/src/wpilib/can.rs
@@ -1,0 +1,44 @@
+use wpilib::hal_call::*;
+use std::convert::From;
+
+/// An error reading or writing to/from the CAN bus
+#[derive(Debug, Copy, Clone)]
+pub enum CanError {
+    /// CAN frame has not been received within specified period of time.
+    RxTimeout,
+    /// Not used.
+    TxTimeout,
+    /// Caller passed an invalid param
+    InvalidParamValue,
+    /// Specified CAN Id is invalid.
+    UnexpectedArbId,
+    /// Could not transmit the CAN frame.
+    TxFailed,
+    /// Have not received an value response for signal.
+    SigNotUpdated,
+    /// Caller attempted to insert data into a buffer that is full.
+    BufferFull,
+    /// Some other error happened
+    Other(HalError)
+}
+
+impl From<i32> for CanError {
+    fn from(value: i32) -> CanError {
+        match value {
+            1 => CanError::RxTimeout,
+            2 => CanError::InvalidParamValue,
+            3 => CanError::UnexpectedArbId,
+            4 => CanError::TxFailed,
+            5 => CanError::SigNotUpdated,
+            6 => CanError::BufferFull,
+            e => CanError::Other(HalError(e)),
+        }
+    }
+}
+
+impl From<HalError> for CanError {
+    fn from(value: HalError) -> CanError {
+        let HalError(value) = value;
+        From::from(value)
+    }
+}

--- a/src/wpilib/mod.rs
+++ b/src/wpilib/mod.rs
@@ -60,3 +60,9 @@ pub use self::pwm_speed_controller::*;
 /// defines all joystick related traits and structs
 pub mod joystick;
 pub use self::joystick::*;
+
+mod can;
+pub use self::can::*;
+
+mod pcm;
+pub use self::pcm::*;

--- a/src/wpilib/pcm.rs
+++ b/src/wpilib/pcm.rs
@@ -1,0 +1,82 @@
+use wpilib::wpilib_hal::*;
+use wpilib::hal_call::*;
+use wpilib::usage::*;
+use wpilib::can::CanError;
+use wpilib::sensor;
+use std::ptr;
+use std::sync;
+
+/// A single-acting solenoid that flushes immediately on write.
+pub struct Solenoid {
+    channel: i32,
+    module: i32,
+    handle: HAL_SolenoidHandle,
+}
+
+/// An error in the creation of a solenoid
+#[derive(Debug, Copy, Clone)]
+pub enum SolenoidCreationError {
+    /// The specified module does not exist
+    ModuleDNE,
+    /// The specified channel is invalid or does not exist
+    ChannelDNE,
+    /// Some other HAL error
+    Other(HalError),
+}
+
+impl Solenoid {
+    /// Create a new solenoid on the specified module, using the default PCM module 0.
+    pub fn new(channel: i32) -> Result<Solenoid, SolenoidCreationError> {
+        Solenoid::new_with_module(0, channel)
+    }
+
+    /// Create a new solenoid on the specified module and channel.
+    pub fn new_with_module(module: i32, channel: i32) -> Result<Solenoid, SolenoidCreationError> {
+        if !sensor::check_solenoid_module(module) {
+            return Err(SolenoidCreationError::ModuleDNE);
+        }
+
+        if !sensor::check_solenoid_channel(channel) {
+            return Err(SolenoidCreationError::ChannelDNE);
+        }
+
+        let handle = hal_call!(HAL_InitializeSolenoidPort(HAL_GetPortWithModule(module, channel)))
+            .map_err(|e| SolenoidCreationError::Other(e))?;
+
+        report_usage_extras(ResourceType::Solenoid, channel, module, ptr::null());
+
+        Ok(Solenoid {
+            channel: channel,
+            module: module,
+            handle: handle,
+        })
+    }
+
+    /// Set the value of the solenoid, flushing immediately to CAN.
+    pub fn set(&mut self, value: bool) -> Result<(), CanError> {
+        hal_call!(HAL_SetSolenoid(self.handle, value as i32)).map_err(From::from)
+    }
+
+    /// Get the most recently set value of the solenoid.
+    pub fn get(&self) -> Result<bool, CanError> {
+        hal_call!(HAL_GetSolenoid(self.handle)).map(|b| b != 0).map_err(From::from)
+    }
+
+    /// Check if the solenoid has been blacklisted by the PCM. A solenoid is blacklisted when it
+    /// becomes shorted, and is not removed from the PCM's blacklist until sticky faults are
+    /// cleared or the robot is rebooted.
+    pub fn is_blacklisted(&self) -> Result<bool, CanError> {
+        match hal_call!(HAL_GetPCMSolenoidBlackList(self.module)) {
+            Ok(blacklist) => Ok((blacklist & (1 << self.channel)) != 0),
+            Err(e) => Err(From::from(e)),
+        }
+    }
+}
+
+impl Drop for Solenoid {
+    fn drop(&mut self) {
+        unsafe {
+            HAL_FreeSolenoidPort(self.handle);
+        }
+    }
+}

--- a/src/wpilib/pcm.rs
+++ b/src/wpilib/pcm.rs
@@ -123,8 +123,8 @@ impl BufferedPcm {
 
     /// Flush the cached values to CAN.
     pub fn flush(&self) -> Result<(), CanError> {
-        let data = self.buffer.lock().unwrap();
-        hal_call!(HAL_SetAllSolenoids(self.module, *data as i32)).map_err(From::from)
+        let data = *self.buffer.lock().unwrap();
+        hal_call!(HAL_SetAllSolenoids(self.module, data as i32)).map_err(From::from)
     }
 }
 

--- a/src/wpilib/pcm.rs
+++ b/src/wpilib/pcm.rs
@@ -96,7 +96,7 @@ pub struct BufferedSolenoid<'a> {
 }
 
 impl BufferedPcm {
-    /// Create a new BufferedPcm on the specified module, returning None if the module is invalid.
+    /// Create a new BufferedPcm on the specified module, returning an Err if the module is invalid.
     pub fn new(module: i32) -> Result<BufferedPcm, SolenoidCreationError> {
         if !sensor::check_solenoid_module(module) {
             Err(SolenoidCreationError::ModuleDNE)
@@ -108,9 +108,11 @@ impl BufferedPcm {
         }
     }
 
-    /// Make a new BufferedSolenoid on this PCM on the specified channel, returning None if the
+    /// Make a new BufferedSolenoid on this PCM on the specified channel, returning an Err if the
     /// channel is invalid.
-    pub fn make_solenoid<'a>(&'a self, channel: i32) -> Result<BufferedSolenoid<'a>, SolenoidCreationError> {
+    pub fn make_solenoid<'a>(&'a self,
+                             channel: i32)
+                             -> Result<BufferedSolenoid<'a>, SolenoidCreationError> {
         if !sensor::check_solenoid_channel(channel) {
             Err(SolenoidCreationError::ChannelDNE)
         } else {

--- a/src/wpilib/pcm.rs
+++ b/src/wpilib/pcm.rs
@@ -80,3 +80,63 @@ impl Drop for Solenoid {
         }
     }
 }
+
+/// A struct representing a PCM object that is buffered and stores values until it is flushed. This
+/// object can create BufferedSolenoids to act as proxies for setting PCM values.
+pub struct BufferedPcm {
+    buffer: sync::Mutex<u8>,
+    module: i32,
+}
+
+/// A single-acting solenoid that caches out values to a BufferedPcm instead of writing directly to
+/// CAN.
+pub struct BufferedSolenoid<'a> {
+    buffer: &'a sync::Mutex<u8>,
+    channel: i32,
+}
+
+impl BufferedPcm {
+    /// Create a new BufferedPcm on the specified module, returning None if the module is invalid.
+    pub fn new(module: i32) -> Result<BufferedPcm, SolenoidCreationError> {
+        if !sensor::check_solenoid_module(module) {
+            Err(SolenoidCreationError::ModuleDNE)
+        } else {
+            Ok(BufferedPcm {
+                buffer: sync::Mutex::new(0),
+                module: module,
+            })
+        }
+    }
+
+    /// Make a new BufferedSolenoid on this PCM on the specified channel, returning None if the
+    /// channel is invalid.
+    pub fn make_solenoid<'a>(&'a self, channel: i32) -> Result<BufferedSolenoid<'a>, SolenoidCreationError> {
+        if !sensor::check_solenoid_channel(channel) {
+            Err(SolenoidCreationError::ChannelDNE)
+        } else {
+            Ok(BufferedSolenoid {
+                buffer: &self.buffer,
+                channel: channel,
+            })
+        }
+    }
+
+    /// Flush the cached values to CAN.
+    pub fn flush(&self) -> Result<(), CanError> {
+        let data = self.buffer.lock().unwrap();
+        hal_call!(HAL_SetAllSolenoids(self.module, *data as i32)).map_err(From::from)
+    }
+}
+
+impl<'a> BufferedSolenoid<'a> {
+    /// Set the value of the solenoid. This will cache values to the BufferedPcm, which will not
+    /// actually write out values to CAN until flush() is called.
+    pub fn set(&mut self, value: bool) {
+        let mut data = self.buffer.lock().unwrap();
+        if value {
+            *data |= 1 << self.channel;
+        } else {
+            *data &= !(1 << self.channel);
+        }
+    }
+}


### PR DESCRIPTION
Code for using the PCM and solenoids, along with a BufferedPcm class to buffer PCM commands and send them all at once (usually for use from a separate thread).